### PR TITLE
New features and shortcut fix

### DIFF
--- a/HexBox.WinUI/HexBox.cs
+++ b/HexBox.WinUI/HexBox.cs
@@ -1607,22 +1607,38 @@ namespace HexBox.WinUI
         {
             base.OnPointerMoved(e);
 
-            switch (_HighlightState)
-            {
-            case SelectionArea.Data:
-            case SelectionArea.Text:
+            if (_HighlightState != SelectionArea.None)
             {
                 var position = e.GetCurrentPoint(_Canvas).Position;
-
                 var currentMouseOverOffset = ConvertPositionToOffset(position);
 
-                if (currentMouseOverOffset >= SelectionStart)
+                switch (_HighlightState)
                 {
-                    SelectionEnd = currentMouseOverOffset + _BytesPerColumn;
-                }
-                else
-                {
-                    SelectionEnd = currentMouseOverOffset;
+                    case SelectionArea.Data:
+                    case SelectionArea.Text:
+                    {
+                        if (currentMouseOverOffset >= SelectionStart)
+                        {
+                            SelectionEnd = currentMouseOverOffset + _BytesPerColumn;
+                        }
+                        else
+                        {
+                            SelectionEnd = currentMouseOverOffset;
+                        }
+                        break;
+                    }
+                    case SelectionArea.Address:
+                    {
+                        if (currentMouseOverOffset >= SelectionStart)
+                        {
+                            SelectionEnd = currentMouseOverOffset + _BytesPerRow;
+                        }
+                        else
+                        {
+                            SelectionEnd = currentMouseOverOffset;
+                        }
+                        break;
+                    }
                 }
 
                 // Move next row into view if selection goes out of view
@@ -1634,9 +1650,6 @@ namespace HexBox.WinUI
                 {
                     ScrollToOffset(currentMouseOverOffset - _BytesPerRow);
                 }
-
-                        break;
-            }
             }
         }
 

--- a/HexBox.WinUI/HexBox.cs
+++ b/HexBox.WinUI/HexBox.cs
@@ -1628,11 +1628,11 @@ namespace HexBox.WinUI
                 // Move next row into view if selection goes out of view
                 if (position.Y > _AddressRect.Y + _AddressRect.Height)
                 {
-                    ScrollToOffset(currentMouseOverOffset + _BytesPerColumn);
+                    ScrollToOffset(currentMouseOverOffset + _BytesPerRow);
                 }
                 else if (position.Y < _AddressRect.Y)
                 {
-                    ScrollToOffset(currentMouseOverOffset - _BytesPerColumn);
+                    ScrollToOffset(currentMouseOverOffset - _BytesPerRow);
                 }
 
                         break;

--- a/HexBox.WinUI/HexBox.cs
+++ b/HexBox.WinUI/HexBox.cs
@@ -609,9 +609,12 @@ namespace HexBox.WinUI
 
                 long savedDataSourcePositionBeforeReadingData = DataSource.BaseStream.Position;
 
-                DataSource.BaseStream.Position = Math.Min(SelectionStart, SelectionEnd);
+                // Adjust wrong SelectionEnd after selecting up or right to left
+                long selectionEnd = SelectionStart < SelectionEnd ? SelectionEnd - 1 : SelectionEnd;
 
-                while (DataSource.BaseStream.Position <= Math.Max(SelectionStart, SelectionEnd))
+                DataSource.BaseStream.Position = Math.Min(SelectionStart, selectionEnd);
+
+                while (DataSource.BaseStream.Position <= Math.Max(SelectionStart, selectionEnd))
                 {
                     if (copyText)
                     {

--- a/HexBox.WinUI/HexBox.cs
+++ b/HexBox.WinUI/HexBox.cs
@@ -1312,7 +1312,7 @@ namespace HexBox.WinUI
                         {
                             e.Handled = true;
 
-                            if (DataSource?.BaseStream?.Length > 0)
+                            if (DataSource != null)
                             {
                                 SelectionStart = 0;
                                 SelectionEnd = DataSource.BaseStream.Length;
@@ -2127,7 +2127,7 @@ namespace HexBox.WinUI
 
         private bool SelectAllCanExecute(object sender)
         {
-            return DataSource?.BaseStream?.Length > 0;
+            return DataSource != null;
         }
 
         private bool CopyCanExecute(object sender)

--- a/HexBox.WinUI/HexBox.cs
+++ b/HexBox.WinUI/HexBox.cs
@@ -609,7 +609,7 @@ namespace HexBox.WinUI
 
                 long savedDataSourcePositionBeforeReadingData = DataSource.BaseStream.Position;
 
-                // Adjust wrong SelectionEnd after selecting up or right to left
+                // Adjust wrong SelectionEnd after selecting down or left to right
                 long selectionEnd = SelectionStart < SelectionEnd ? SelectionEnd - 1 : SelectionEnd;
 
                 DataSource.BaseStream.Position = Math.Min(SelectionStart, selectionEnd);

--- a/HexBox.WinUI/HexBox.cs
+++ b/HexBox.WinUI/HexBox.cs
@@ -610,7 +610,7 @@ namespace HexBox.WinUI
                 long savedDataSourcePositionBeforeReadingData = DataSource.BaseStream.Position;
 
                 // Adjust wrong SelectionEnd after selecting down or left to right
-                long selectionEnd = SelectionStart < SelectionEnd ? SelectionEnd - 1 : SelectionEnd;
+                long selectionEnd = SelectionStart < SelectionEnd ? SelectionEnd - _BytesPerColumn : SelectionEnd;
 
                 DataSource.BaseStream.Position = Math.Min(SelectionStart, selectionEnd);
 

--- a/HexBox.WinUI/HexBox.cs
+++ b/HexBox.WinUI/HexBox.cs
@@ -1324,21 +1324,20 @@ namespace HexBox.WinUI
 
                     case VirtualKey.C:
                     {
-                        if ((IsKeyDown(VirtualKey.LeftControl) || IsKeyDown(VirtualKey.RightControl)) &&
-                                (IsKeyDown(VirtualKey.LeftShift) || IsKeyDown(VirtualKey.RightShift)))
+                        if (IsKeyDown(VirtualKey.LeftControl) || IsKeyDown(VirtualKey.RightControl))
                         {
-                            // Copy text
                             if (CopyCanExecute(null))
                             {
-                                Copy(true);
-                            }
-                        }
-                        else if ((IsKeyDown(VirtualKey.LeftControl) || IsKeyDown(VirtualKey.RightControl)))
-                        {
-                            // Copy data
-                            if (CopyCanExecute(null))
-                            {
-                                Copy(false);
+                                if (IsKeyDown(VirtualKey.LeftShift) || IsKeyDown(VirtualKey.RightShift))
+                                {
+                                    // Copy text
+                                    Copy(true);
+                                }
+                                else
+                                {
+                                    // Copy data
+                                    Copy(false);
+                                }
                             }
                         }
 

--- a/HexBox.WinUI/HexBox.cs
+++ b/HexBox.WinUI/HexBox.cs
@@ -1312,7 +1312,7 @@ namespace HexBox.WinUI
                         {
                             e.Handled = true;
 
-                            if (DataSource != null)
+                            if (SelectAllCanExecute(null))
                             {
                                 SelectionStart = 0;
                                 SelectionEnd = DataSource.BaseStream.Length;
@@ -1328,7 +1328,7 @@ namespace HexBox.WinUI
                         {
                             e.Handled = true;
 
-                            if (IsSelectionActive)
+                            if (CopyCanExecute(null))
                             {
                                 Copy(false);
                             }
@@ -1343,7 +1343,7 @@ namespace HexBox.WinUI
                         {
                             e.Handled = true;
 
-                            if (IsSelectionActive)
+                            if (CopyCanExecute(null))
                             {
                                 Copy(false);
                             }
@@ -2127,12 +2127,12 @@ namespace HexBox.WinUI
 
         private bool SelectAllCanExecute(object sender)
         {
-            return DataSource != null;
+            return DataSource != null && (ShowData || ShowText);
         }
 
         private bool CopyCanExecute(object sender)
         {
-            return IsSelectionActive;
+            return IsSelectionActive && (ShowData || ShowText);
         }
 
         private void OnVerticalScrollBarValueChanged(object sender, RangeBaseValueChangedEventArgs e)

--- a/HexBox.WinUI/HexBox.cs
+++ b/HexBox.WinUI/HexBox.cs
@@ -1659,13 +1659,13 @@ namespace HexBox.WinUI
                         if (SelectionStart > SelectionEnd && _pointerMoveSelectionAdjustment != SelectionAdjustment.Up)
                         {
                             // If moving up and SelectionStart was previously adjusted down or not adjusted, then set SelectionStart to end of row.
-                            SelectionStart = SelectionStart + (_BytesPerRow -1);
+                            SelectionStart = SelectionStart + (_BytesPerRow - _BytesPerColumn);
                             _pointerMoveSelectionAdjustment = SelectionAdjustment.Up;
                         }
                         else if (SelectionStart < SelectionEnd && _pointerMoveSelectionAdjustment == SelectionAdjustment.Up)
                         {
                             // If moving down and SelectionStart was previously adjusted up, then set SelectionStart to start of row.
-                            SelectionStart = SelectionStart - (_BytesPerRow -1);
+                            SelectionStart = SelectionStart - (_BytesPerRow - _BytesPerColumn);
                             _pointerMoveSelectionAdjustment = SelectionAdjustment.Down;
                         }
                         break;

--- a/HexBox.WinUI/HexBox.cs
+++ b/HexBox.WinUI/HexBox.cs
@@ -564,6 +564,15 @@ namespace HexBox.WinUI
 
 
         /// <summary>
+        /// Clears the current selection
+        /// </summary>
+        public void ClearSelection()
+        {
+            SelectionStart = SelectionEnd = 0;
+        }
+
+
+        /// <summary>
         /// Select all data.
         /// </summary>
         public void SelectAll()

--- a/HexBox.WinUI/HexBox.cs
+++ b/HexBox.WinUI/HexBox.cs
@@ -1281,6 +1281,17 @@ namespace HexBox.WinUI
         public void ScrollToOffset(long offset)
         {
             long maxBytesDisplayed = _BytesPerRow * MaxVisibleRows;
+            long lastByteOffset = (DataSource?.BaseStream?.Length ?? 1) - 1;
+
+            // Adjust requested offset if not existing
+            if (offset < 0)
+            {
+                offset = 0;
+            }
+            else if (offset > lastByteOffset)
+            {
+                offset = lastByteOffset;
+            }
 
             if (Offset > offset)
             {

--- a/HexBox.WinUI/HexBox.cs
+++ b/HexBox.WinUI/HexBox.cs
@@ -1295,7 +1295,8 @@ namespace HexBox.WinUI
             }          
         }
 
-        private static bool IsKeyDown(VirtualKey key) => InputKeyboardSource.GetKeyStateForCurrentThread(key) == CoreVirtualKeyStates.Down;
+        // Using .HasFlag(x) to correctly detect state of modifier keys (CTRL, SHIFT, ...)
+        private static bool IsKeyDown(VirtualKey key) => InputKeyboardSource.GetKeyStateForCurrentThread(key).HasFlag(CoreVirtualKeyStates.Down);
 
         /// <inheritdoc/>
         protected override void OnKeyDown(KeyRoutedEventArgs e)

--- a/HexBox.WinUI/HexBox.cs
+++ b/HexBox.WinUI/HexBox.cs
@@ -563,7 +563,6 @@ namespace HexBox.WinUI
             DependencyProperty.Register("HighlightedRegions", typeof(List<HighlightedRegion>), typeof(HexBox), new PropertyMetadata(new List<HighlightedRegion>(), OnPropertyChangedInvalidateVisual));
 
 
-
         /// <summary>
         /// Select all data.
         /// </summary>
@@ -1618,12 +1617,11 @@ namespace HexBox.WinUI
 
                 switch (_HighlightState)
                 {
-                    case SelectionArea.Data:
-                    case SelectionArea.Text:
+                    case SelectionArea.Address:
                     {
                         if (currentMouseOverOffset >= SelectionStart)
                         {
-                            SelectionEnd = currentMouseOverOffset + _BytesPerColumn;
+                            SelectionEnd = currentMouseOverOffset + _BytesPerRow;
                         }
                         else
                         {
@@ -1631,11 +1629,12 @@ namespace HexBox.WinUI
                         }
                         break;
                     }
-                    case SelectionArea.Address:
+                    case SelectionArea.Data:
+                    case SelectionArea.Text:
                     {
                         if (currentMouseOverOffset >= SelectionStart)
                         {
-                            SelectionEnd = currentMouseOverOffset + _BytesPerRow;
+                            SelectionEnd = currentMouseOverOffset + _BytesPerColumn;
                         }
                         else
                         {

--- a/HexBox.WinUI/HexBox.cs
+++ b/HexBox.WinUI/HexBox.cs
@@ -1626,9 +1626,13 @@ namespace HexBox.WinUI
                 }
 
                 // Move next row into view if selection goes out of view
-                if (!IsOffsetVisible(SelectionEnd + _BytesPerColumn))
+                if (position.Y > _AddressRect.Y + _AddressRect.Height)
                 {
-                    ScrollToOffset(SelectionEnd + _BytesPerColumn);
+                    ScrollToOffset(currentMouseOverOffset + _BytesPerColumn);
+                }
+                else if (position.Y < _AddressRect.Y)
+                {
+                    ScrollToOffset(currentMouseOverOffset - _BytesPerColumn);
                 }
 
                         break;

--- a/HexBox.WinUI/HexBox.cs
+++ b/HexBox.WinUI/HexBox.cs
@@ -1310,8 +1310,6 @@ namespace HexBox.WinUI
                     {
                         if (IsKeyDown(VirtualKey.LeftControl) || IsKeyDown(VirtualKey.RightControl))
                         {
-                            e.Handled = true;
-
                             if (SelectAllCanExecute(null))
                             {
                                 SelectionStart = 0;
@@ -1319,36 +1317,31 @@ namespace HexBox.WinUI
                             }
                         }
 
+                        e.Handled = true;
                         break;
                     }
 
                     case VirtualKey.C:
                     {
-                        if (IsKeyDown(VirtualKey.LeftControl) || IsKeyDown(VirtualKey.RightControl))
+                        if ((IsKeyDown(VirtualKey.LeftControl) || IsKeyDown(VirtualKey.RightControl)) &&
+                                (IsKeyDown(VirtualKey.LeftShift) || IsKeyDown(VirtualKey.RightShift)))
                         {
-                            e.Handled = true;
-
+                            // Copy text
+                            if (CopyCanExecute(null))
+                            {
+                                Copy(true);
+                            }
+                        }
+                        else if ((IsKeyDown(VirtualKey.LeftControl) || IsKeyDown(VirtualKey.RightControl)))
+                        {
+                            // Copy data
                             if (CopyCanExecute(null))
                             {
                                 Copy(false);
                             }
                         }
 
-                        break;
-                    }
-
-                    case VirtualKey.T:
-                    {
-                        if (IsKeyDown(VirtualKey.LeftControl) || IsKeyDown(VirtualKey.RightControl))
-                        {
-                            e.Handled = true;
-
-                            if (CopyCanExecute(null))
-                            {
-                                Copy(false);
-                            }
-                        }
-
+                        e.Handled = true;
                         break;
                     }
 

--- a/HexBox.WinUI/Themes/Generic.xaml
+++ b/HexBox.WinUI/Themes/Generic.xaml
@@ -29,17 +29,30 @@
                                 <MenuFlyoutItem
                                     Command="{Binding CopyCommand, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                     Icon="Copy"
-                                    Text="Copy" />
+                                    Text="Copy">
+                                    <MenuFlyoutItem.KeyboardAccelerators>
+                                        <KeyboardAccelerator Key="C" Modifiers="Control" />
+                                    </MenuFlyoutItem.KeyboardAccelerators>
+                                </MenuFlyoutItem>
                                 <MenuFlyoutItem
                                     Command="{Binding CopyTextCommand, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                     Icon="Font"
-                                    Text="Copy text" />
+                                    Text="Copy text">
+                                    <MenuFlyoutItem.KeyboardAccelerators>
+                                        <KeyboardAccelerator Key="T" Modifiers="Control" />
+                                    </MenuFlyoutItem.KeyboardAccelerators>
+                                </MenuFlyoutItem>
+                                <MenuFlyoutItem
+                                    Command="{Binding SelectAllCommand, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                    Icon="SelectAll"
+                                    Text="Select all">
+                                    <MenuFlyoutItem.KeyboardAccelerators>
+                                        <KeyboardAccelerator Key="A" Modifiers="Control" />
+                                    </MenuFlyoutItem.KeyboardAccelerators>
+                                </MenuFlyoutItem>
                                 <MenuFlyoutSeparator />
-                                <MenuFlyoutSubItem IsEnabled="{Binding EnforceProperties, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
-                                                   Text="Address properties">
-                                    <ToggleMenuFlyoutItem
-                                        IsChecked="{Binding ShowAddress, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=TwoWay, Converter={StaticResource BoolNegationConverter}}"
-                                                     Text="No Address" />
+                                <MenuFlyoutSubItem IsEnabled="{Binding EnforceProperties, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}" Text="Address properties">
+                                    <ToggleMenuFlyoutItem IsChecked="{Binding ShowAddress, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=TwoWay, Converter={StaticResource BoolNegationConverter}}" Text="No Address" />
                                 </MenuFlyoutSubItem>
                                 <MenuFlyoutSubItem IsEnabled="{Binding EnforceProperties, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}" Text="Data properties">
                                     <ToggleMenuFlyoutItem IsChecked="{Binding ShowData, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=TwoWay, Converter={StaticResource BoolNegationConverter}}" Text="No Data" />
@@ -104,23 +117,24 @@
                             <ColumnDefinition Width="24" />
                         </Grid.ColumnDefinitions>
 
-                        <skia:SKXamlCanvas Grid.Column="0"
-                                           Name="ElementCanvas"
-                                           Margin="2,0,2,0"
-                                           VerticalAlignment="Stretch"
-                                           HorizontalAlignment="Stretch"
-                                           ContextFlyout="{StaticResource DataMenuFlyout}">
-                        </skia:SKXamlCanvas>
+                        <skia:SKXamlCanvas
+                            Name="ElementCanvas"
+                            Grid.Column="0"
+                            Margin="2,0,2,0"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            ContextFlyout="{StaticResource DataMenuFlyout}" />
 
-                        <ScrollBar Grid.Column="1"
-                                   Name="ElementScrollBar"
-                                   VerticalAlignment="Stretch"
-                                   HorizontalAlignment="Stretch"
-                                   Margin="0,0,2,0"
-                                   IndicatorMode="MouseIndicator"
-                                   Orientation="Vertical"
-                                   FontFamily="{TemplateBinding FontFamily}"
-                                   FontSize="{TemplateBinding FontSize}" />
+                        <ScrollBar
+                            Name="ElementScrollBar"
+                            Grid.Column="1"
+                            Margin="0,0,2,0"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            FontFamily="{TemplateBinding FontFamily}"
+                            FontSize="{TemplateBinding FontSize}"
+                            IndicatorMode="MouseIndicator"
+                            Orientation="Vertical" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/HexBox.WinUI/Themes/Generic.xaml
+++ b/HexBox.WinUI/Themes/Generic.xaml
@@ -39,7 +39,7 @@
                                     Icon="Font"
                                     Text="Copy text">
                                     <MenuFlyoutItem.KeyboardAccelerators>
-                                        <KeyboardAccelerator Key="T" Modifiers="Control" />
+                                        <KeyboardAccelerator Key="C" Modifiers="Control,Shift"/>
                                     </MenuFlyoutItem.KeyboardAccelerators>
                                 </MenuFlyoutItem>
                                 <MenuFlyoutItem


### PR DESCRIPTION
This PR adds the following new features:
- Context menu entries showing their shortcuts.
- A new context menu entry to "select all" data. (#17)
- Shortcut CTRL+C for copy the data. (#15)
- Shortcut CTRL+Shift+C for copy the text. (#15)
- Autoscroll when selection with mouse reaches the last visible data. (#18)
- Selecting multiple rows by address while holding and moving mouse.
- Disable copy and selection if Data and Text are hidden.
- Added a public method to clear selection.

This PR fixes:
- Wrong detection of key down state (#16)
- Bug that allows scrolling content out of view.
- Wrong copy if user selected from top to bottom or left to right.

<details>

<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/de2497ce-a697-40ef-b8b2-2e851849f7d0)

![hexbox_autoscroll](https://github.com/user-attachments/assets/5f97e5b7-af63-4114-8932-3606a9320233)

![hexbox_multiselectaddress](https://github.com/user-attachments/assets/506dc863-20a0-4685-abb3-cc926c401430)

</details>
