### PR TITLE
XAML Template: Padding and CornerRadius

### DIFF
--- a/HexBox.WinUI/Themes/Generic.xaml
+++ b/HexBox.WinUI/Themes/Generic.xaml
@@ -16,7 +16,9 @@
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
-                        IsTabStop="False">
+                        IsTabStop="False"
+                        Padding="4"
+                        CornerRadius="{TemplateBinding CornerRadius}">
 
                         <Grid.Resources>
                             <convert:BoolNegationConverter x:Key="BoolNegationConverter" />


### PR DESCRIPTION
Add support for setting CornerRadius and added Padding of 4.
With Padding it looks a bit better and the CornerRadius property allows rounded corners in WinUI apps.

This is how it looks with this changes and defined corner radius:

![image](https://github.com/user-attachments/assets/10518b29-161a-45eb-88fd-8847c0bd739c)

To use the corner radius u have to set `CornerRadius="{StaticResource ControlCornerRadius}"` in xaml code where the control is implemented.
